### PR TITLE
Add CHANGELOG.md with initial commit history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - hexagonal-typeScript
+
+## Últimos cambios
+
+| # | SHA del Commit | Mensaje | Autor | Fecha |
+|---|---------------|---------|-------|-------|
+| 1 | `c17b5ad0ab0e756d6b7a53c190d5e29876c5e1b4` | Initial commit | Denis Santiago (@denissanthiago) | 2024-03-14 |


### PR DESCRIPTION
## Proposed changes

This pull request adds a `CHANGELOG.md` file to the hexagonal-typeScript repository to track project changes and commit history. The changelog documents the initial commit with relevant metadata including commit SHA, message, author, and date.

## Checklist

- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The changelog follows a standard format with a table structure for easy readability and maintenance. This provides a clear history of project changes for contributors and users.

https://claude.ai/code/session_01Tev2nQKHHSc2AAmji3tCag